### PR TITLE
fix: wire `ImportService`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-flz"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef71f23a8caf6f2a2d5cafbdc44956d44e6014dcb9aa58abf7e4e6481c6ec34"
+checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
@@ -6787,7 +6787,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6833,7 +6833,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6857,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6888,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6922,7 +6922,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7028,7 +7028,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -7059,7 +7059,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7086,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7122,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7148,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7205,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7329,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7389,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "futures",
  "pin-project",
@@ -7436,7 +7436,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7515,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7531,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "bytes 1.10.1",
@@ -7546,7 +7546,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -7566,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7577,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7606,7 +7606,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7689,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7705,7 +7705,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7723,7 +7723,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7737,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7764,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7782,7 +7782,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7904,7 +7904,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "serde",
  "serde_json",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7956,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "bytes 1.10.1",
  "futures",
@@ -7976,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7993,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "bindgen",
  "cc",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "futures",
  "metrics",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
 ]
@@ -8022,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8091,7 +8091,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -8114,7 +8114,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8137,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8152,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8322,7 +8322,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8382,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8403,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8538,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8558,7 +8558,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8616,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8685,7 +8685,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8704,7 +8704,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8724,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -8738,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8770,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8876,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8916,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8991,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9056,7 +9056,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9129,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9201,7 +9201,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9287,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9301,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9357,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9391,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "clap",
  "eyre",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9535,7 +9535,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9578,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.7"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.7#dc7cb6e6670b0da294a0e5010e02855f5aaf6b49"
+source = "git+https://github.com/paradigmxyz/reth?rev=66692a7#66692a7e458d04e6ab5d993cbce8331862bef975"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,43 +8,43 @@ name = "reth_bsc"
 path = "src/lib.rs"
 
 [[bin]]
-name = "reth"
+name = "reth-bsc"
 path = "src/main.rs"
 
 [dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7", features = ["test-utils"] }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7", features = ["serde"] }
-reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7", features = ["test-utils"] }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7", features = ["test-utils"] }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7", features = ["test-utils"] }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.7" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-discv4 = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7", features = ["test-utils"] }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7", features = ["serde"] }
+reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7", features = ["test-utils"] }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7", features = ["test-utils"] }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7", features = ["test-utils"] }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "66692a7" }
 revm = { version = "24.0.1", features = ["secp256r1"] }
 
 # alloy dependencies

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+reorder_imports = true
+imports_granularity = "Crate"
+use_small_heuristics = "Max"
+comment_width = 100
+wrap_comments = true
+binop_separator = "Back"
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 100

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,8 @@ use clap::{Args, Parser};
 use reth::builder::NodeHandle;
 use reth_bsc::{
     chainspec::parser::BscChainSpecParser,
-    consensus::ParliaConsensus,
-    node::network::block_import::service::ImportService as BlockImportService,
     node::{cli::Cli, BscNode},
 };
-use std::sync::Arc;
-use tracing::error;
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]
@@ -28,19 +24,13 @@ fn main() -> eyre::Result<()> {
     }
 
     Cli::<BscChainSpecParser, NoArgs>::parse().run(|builder, _| async move {
+        let (node, engine_handle_tx) = BscNode::new();
         let NodeHandle {
             node,
             node_exit_future: exit_future,
-        } = builder.node(BscNode::default()).launch().await?;
-        let provider = node.provider.clone();
-        let consensus = Arc::new(ParliaConsensus { provider });
-        let (service, _) = BlockImportService::new(consensus, node.beacon_engine_handle.clone());
+        } = builder.node(node).launch().await?;
 
-        node.task_executor.spawn(async move {
-            if let Err(e) = service.await {
-                error!("Import service error: {}", e);
-            }
-        });
+        engine_handle_tx.send(node.beacon_engine_handle.clone()).unwrap();
 
         exit_future.await
     })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,8 @@ fn main() -> eyre::Result<()> {
 
     Cli::<BscChainSpecParser, NoArgs>::parse().run(|builder, _| async move {
         let (node, engine_handle_tx) = BscNode::new();
-        let NodeHandle {
-            node,
-            node_exit_future: exit_future,
-        } = builder.node(node).launch().await?;
+        let NodeHandle { node, node_exit_future: exit_future } =
+            builder.node(node).launch().await?;
 
         engine_handle_tx.send(node.beacon_engine_handle.clone()).unwrap();
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -41,17 +41,9 @@ pub struct BscNode {
 }
 
 impl BscNode {
-    pub fn new() -> (
-        Self,
-        oneshot::Sender<BeaconConsensusEngineHandle<BscPayloadTypes>>,
-    ) {
+    pub fn new() -> (Self, oneshot::Sender<BeaconConsensusEngineHandle<BscPayloadTypes>>) {
         let (tx, rx) = oneshot::channel();
-        (
-            Self {
-                engine_handle_rx: Arc::new(Mutex::new(Some(rx))),
-            },
-            tx,
-        )
+        (Self { engine_handle_rx: Arc::new(Mutex::new(Some(rx))) }, tx)
     }
 }
 
@@ -80,9 +72,7 @@ impl BscNode {
             .pool(EthereumPoolBuilder::default())
             .executor(BscExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::default())
-            .network(BscNetworkBuilder {
-                engine_handle_rx: self.engine_handle_rx.clone(),
-            })
+            .network(BscNetworkBuilder { engine_handle_rx: self.engine_handle_rx.clone() })
             .consensus(BscConsensusBuilder::default())
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{chainspec::BscChainSpec, node::rpc::BscEthApiBuilder};
 
 use crate::node::rpc::engine_api::{
@@ -14,10 +16,12 @@ use reth::{
         DebugNode, Node, NodeAdapter, NodeComponentsBuilder,
     },
 };
+use reth_engine_primitives::BeaconConsensusEngineHandle;
 use reth_node_ethereum::node::{EthereumPayloadBuilder, EthereumPoolBuilder};
 use reth_primitives::{Block, BlockBody, EthPrimitives};
 use reth_provider::EthStorage;
 use reth_trie_db::MerklePatriciaTrie;
+use tokio::sync::{oneshot, Mutex};
 
 pub mod cli;
 pub mod consensus;
@@ -30,9 +34,26 @@ pub type BscNodeAddOns<N> =
     RpcAddOns<N, BscEthApiBuilder, BscEngineValidatorBuilder, BscEngineApiBuilder>;
 
 /// Type configuration for a regular BSC node.
-#[derive(Debug, Default, Clone)]
-#[non_exhaustive]
-pub struct BscNode;
+#[derive(Debug, Clone)]
+pub struct BscNode {
+    engine_handle_rx:
+        Arc<Mutex<Option<oneshot::Receiver<BeaconConsensusEngineHandle<BscPayloadTypes>>>>>,
+}
+
+impl BscNode {
+    pub fn new() -> (
+        Self,
+        oneshot::Sender<BeaconConsensusEngineHandle<BscPayloadTypes>>,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                engine_handle_rx: Arc::new(Mutex::new(Some(rx))),
+            },
+            tx,
+        )
+    }
+}
 
 impl BscNode {
     pub fn components<Node>(
@@ -59,21 +80,16 @@ impl BscNode {
             .pool(EthereumPoolBuilder::default())
             .executor(BscExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::default())
-            .network(BscNetworkBuilder::default())
+            .network(BscNetworkBuilder {
+                engine_handle_rx: self.engine_handle_rx.clone(),
+            })
             .consensus(BscConsensusBuilder::default())
     }
 }
 
 impl<N> Node<N> for BscNode
 where
-    N: FullNodeTypes<
-        Types: NodeTypes<
-            Payload = BscPayloadTypes,
-            ChainSpec = BscChainSpec,
-            Primitives = EthPrimitives,
-            Storage = EthStorage,
-        >,
-    >,
+    N: FullNodeTypes<Types = Self>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,

--- a/src/node/network/block_import/handle.rs
+++ b/src/node/network/block_import/handle.rs
@@ -14,32 +14,33 @@ use super::service::{BlockMsg, ImportEvent, IncomingBlock, Outcome};
 /// [`super::service::ImportService`]:
 /// - Blocks can be sent to the service for import via [`send_block`](ImportHandle::send_block)
 /// - Import outcomes can be received via [`poll_outcome`](ImportHandle::poll_outcome)`
-pub struct ImportHandle<T: PayloadTypes> {
+#[derive(Debug)]
+pub struct ImportHandle {
     /// Send the new block to the service
-    to_import: UnboundedSender<IncomingBlock<T>>,
+    to_import: UnboundedSender<IncomingBlock>,
     /// Receive the event(Announcement/Outcome) of the import
-    import_outcome: UnboundedReceiver<ImportEvent<T>>,
+    import_outcome: UnboundedReceiver<ImportEvent>,
 }
 
-impl<T: PayloadTypes> ImportHandle<T> {
+impl ImportHandle {
     /// Create a new handle with the provided channels
     pub fn new(
-        to_import: UnboundedSender<IncomingBlock<T>>,
-        import_outcome: UnboundedReceiver<ImportEvent<T>>,
+        to_import: UnboundedSender<IncomingBlock>,
+        import_outcome: UnboundedReceiver<ImportEvent>,
     ) -> Self {
         Self { to_import, import_outcome }
     }
 
     /// Sends the block to import to the service.
     /// Returns a [`BlockImportError`] if the channel to the import service is closed.
-    pub fn send_block(&self, block: BlockMsg<T>, peer_id: PeerId) -> Result<(), BlockImportError> {
+    pub fn send_block(&self, block: BlockMsg, peer_id: PeerId) -> Result<(), BlockImportError> {
         self.to_import
             .send((block, peer_id))
             .map_err(|_| BlockImportError::Other("block import service channel closed".into()))
     }
 
     /// Poll for the next import event
-    pub fn poll_outcome(&mut self, cx: &mut Context<'_>) -> Poll<Option<ImportEvent<T>>> {
+    pub fn poll_outcome(&mut self, cx: &mut Context<'_>) -> Poll<Option<ImportEvent>> {
         self.import_outcome.poll_recv(cx)
     }
 }

--- a/src/node/network/block_import/service.rs
+++ b/src/node/network/block_import/service.rs
@@ -94,10 +94,9 @@ where
 
             match engine.new_payload(payload).await {
                 Ok(payload_status) => match payload_status.status {
-                    PayloadStatusEnum::Valid => Outcome {
-                        peer: peer_id,
-                        result: Ok(BlockValidation::ValidBlock { block }),
-                    },
+                    PayloadStatusEnum::Valid => {
+                        Outcome { peer: peer_id, result: Ok(BlockValidation::ValidBlock { block }) }
+                    }
                     PayloadStatusEnum::Invalid { validation_error } => Outcome {
                         peer: peer_id,
                         result: Err(BlockImportError::Other(validation_error.into())),
@@ -113,16 +112,9 @@ where
                         result: Err(BlockImportError::Other("Unsupported payload status".into())),
                     },
                 },
-<<<<<<< HEAD
                 Err(err) => {
-                    Outcome::<T> { peer: peer_id, result: Err(BlockImportError::Other(err.into())) }
+                    Outcome { peer: peer_id, result: Err(BlockImportError::Other(err.into())) }
                 }
-=======
-                Err(err) => Outcome {
-                    peer: peer_id,
-                    result: Err(BlockImportError::Other(err.into())),
-                },
->>>>>>> 679600d (fix: wire ImportService)
             }
         })
     }
@@ -139,10 +131,7 @@ where
             let (head_block_hash, current_hash) = match consensus.canonical_head(hash, number) {
                 Ok(hash) => hash,
                 Err(ParliaConsensusErr::Provider(e)) => {
-                    return Outcome {
-                        peer: peer_id,
-                        result: Err(BlockImportError::Other(e.into())),
-                    }
+                    return Outcome { peer: peer_id, result: Err(BlockImportError::Other(e.into())) }
                 }
                 Err(ParliaConsensusErr::HeadHashNotFound) => {
                     return Outcome {
@@ -161,10 +150,9 @@ where
             match engine.fork_choice_updated(state, None, EngineApiMessageVersion::default()).await
             {
                 Ok(response) => match response.payload_status.status {
-                    PayloadStatusEnum::Valid => Outcome {
-                        peer: peer_id,
-                        result: Ok(BlockValidation::ValidBlock { block }),
-                    },
+                    PayloadStatusEnum::Valid => {
+                        Outcome { peer: peer_id, result: Ok(BlockValidation::ValidBlock { block }) }
+                    }
                     PayloadStatusEnum::Invalid { validation_error } => Outcome {
                         peer: peer_id,
                         result: Err(BlockImportError::Other(validation_error.into())),
@@ -182,16 +170,9 @@ where
                         )),
                     },
                 },
-<<<<<<< HEAD
                 Err(err) => {
-                    Outcome::<T> { peer: peer_id, result: Err(BlockImportError::Other(err.into())) }
+                    Outcome { peer: peer_id, result: Err(BlockImportError::Other(err.into())) }
                 }
-=======
-                Err(err) => Outcome {
-                    peer: peer_id,
-                    result: Err(BlockImportError::Other(err.into())),
-                },
->>>>>>> 679600d (fix: wire ImportService)
             }
         })
     }
@@ -415,16 +396,10 @@ mod tests {
     fn create_test_block() -> NewBlockMessage<BscNewBlock> {
         let block: reth_primitives::Block = Block::default();
         let new_block = BscNewBlock {
-            inner: NewBlock {
-                block: block.clone(),
-                td: U128::ZERO,
-            },
+            inner: NewBlock { block: block.clone(), td: U128::ZERO },
             sidecars: Default::default(),
         };
-        NewBlockMessage {
-            hash: block.header.hash_slow(),
-            block: Arc::new(new_block),
-        }
+        NewBlockMessage { hash: block.header.hash_slow(), block: Arc::new(new_block) }
     }
 
     /// Helper function to handle engine messages with specified payload statuses

--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -30,6 +30,7 @@ pub mod block_import;
 pub mod handshake;
 pub(crate) mod upgrade_status;
 
+/// BSC representation of a EIP-4844 sidecar.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
 pub struct BscP2PSidecar {
     pub inner: BlobTransactionSidecar,
@@ -39,6 +40,7 @@ pub struct BscP2PSidecar {
     pub tx_hash: B256,
 }
 
+/// BSC `NewBlock` message value.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BscNewBlock {
     pub inner: NewBlock,

--- a/src/node/rpc/block.rs
+++ b/src/node/rpc/block.rs
@@ -18,7 +18,7 @@ use reth::{
 };
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
-use reth_primitives::NodePrimitives;
+use reth_primitives::EthPrimitives;
 use reth_primitives_traits::BlockBody as _;
 use reth_provider::{
     BlockReader, ChainSpecProvider, HeaderProvider, ProviderBlock, ProviderReceipt, ProviderTx,
@@ -112,15 +112,7 @@ where
         > + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: ConfigureEvm<
-            Primitives: NodePrimitives<
-                SignedTx = ProviderTx<Self::Provider>,
-                BlockHeader = ProviderHeader<Self::Provider>,
-                Receipt = ProviderReceipt<Self::Provider>,
-                Block = ProviderBlock<Self::Provider>,
-            >,
-            NextBlockEnvCtx = NextBlockEnvAttributes,
-        >,
+        Evm: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
 {
     #[inline]

--- a/src/node/rpc/transaction.rs
+++ b/src/node/rpc/transaction.rs
@@ -13,6 +13,7 @@ use reth::{
     },
     transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool},
 };
+use reth_primitives::EthPrimitives;
 use reth_provider::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
@@ -26,10 +27,11 @@ where
 {
 }
 
-impl<N> TransactionCompat<TransactionSigned> for BscEthApi<N>
+impl<N> TransactionCompat for BscEthApi<N>
 where
     N: FullNodeComponents<Provider: ReceiptProvider<Receipt = Receipt>>,
 {
+    type Primitives = EthPrimitives;
     type Transaction = <Ethereum as Network>::TransactionResponse;
 
     type Error = EthApiError;

--- a/src/system_contracts/mod.rs
+++ b/src/system_contracts/mod.rs
@@ -33,24 +33,13 @@ impl<Spec: EthChainSpec> SystemContract<Spec> {
     pub(crate) fn new(chain_spec: Spec) -> Self {
         let validator_abi = serde_json::from_str(*VALIDATOR_SET_ABI).unwrap();
         let stake_hub_abi = serde_json::from_str(*STAKE_HUB_ABI).unwrap();
-        Self {
-            validator_abi,
-            stake_hub_abi,
-            chain_spec,
-        }
+        Self { validator_abi, stake_hub_abi, chain_spec }
     }
 
     /// Creates a deposit tx to pay block reward to a validator.
     pub fn pay_validator_tx(&self, address: Address, block_reward: u128) -> TransactionSigned {
-        let function = self
-            .validator_abi
-            .function("deposit")
-            .unwrap()
-            .first()
-            .unwrap();
-        let input = function
-            .abi_encode_input(&[DynSolValue::Address(address)])
-            .unwrap();
+        let function = self.validator_abi.function("deposit").unwrap().first().unwrap();
+        let input = function.abi_encode_input(&[DynSolValue::Address(address)]).unwrap();
 
         let signature = Signature::new(Default::default(), Default::default(), false);
 
@@ -87,12 +76,7 @@ impl<Spec: EthChainSpec> SystemContract<Spec> {
     }
 
     pub(crate) fn genesis_contracts_txs(&self) -> Vec<TransactionSigned> {
-        let function = self
-            .validator_abi
-            .function("init")
-            .unwrap()
-            .first()
-            .unwrap();
+        let function = self.validator_abi.function("init").unwrap().first().unwrap();
         let input = function.abi_encode_input(&[]).unwrap();
 
         let contracts = vec![
@@ -127,12 +111,7 @@ impl<Spec: EthChainSpec> SystemContract<Spec> {
 
     pub(crate) fn feynman_contracts_txs(&self) -> Vec<TransactionSigned> {
         println!("feynman_contracts_txs");
-        let function = self
-            .stake_hub_abi
-            .function("initialize")
-            .unwrap()
-            .first()
-            .unwrap();
+        let function = self.stake_hub_abi.function("initialize").unwrap().first().unwrap();
         let input = function.abi_encode_input(&[]).unwrap();
 
         let signature = Signature::new(Default::default(), Default::default(), false);
@@ -226,10 +205,7 @@ impl SystemContractName {
 
 fn get_all_system_contracts() -> Vec<SystemContractName> {
     let res = vec![
-        SystemContractName::new(
-            "ValidatorContract".to_string(),
-            VALIDATOR_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("ValidatorContract".to_string(), VALIDATOR_CONTRACT.to_string()),
         SystemContractName::new("SlashContract".to_string(), SLASH_CONTRACT.to_string()),
         SystemContractName::new(
             "SystemRewardContract".to_string(),
@@ -239,52 +215,28 @@ fn get_all_system_contracts() -> Vec<SystemContractName> {
             "LightClientContract".to_string(),
             LIGHT_CLIENT_CONTRACT.to_string(),
         ),
-        SystemContractName::new(
-            "TokenHubContract".to_string(),
-            TOKEN_HUB_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("TokenHubContract".to_string(), TOKEN_HUB_CONTRACT.to_string()),
         SystemContractName::new(
             "RelayerIncentivizeContract".to_string(),
             RELAYER_INCENTIVIZE_CONTRACT.to_string(),
         ),
-        SystemContractName::new(
-            "RelayerHubContract".to_string(),
-            RELAYER_HUB_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("RelayerHubContract".to_string(), RELAYER_HUB_CONTRACT.to_string()),
         SystemContractName::new("GovHubContract".to_string(), GOV_HUB_CONTRACT.to_string()),
-        SystemContractName::new(
-            "TokenHubContract".to_string(),
-            TOKEN_HUB_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("TokenHubContract".to_string(), TOKEN_HUB_CONTRACT.to_string()),
         SystemContractName::new(
             "TokenManagerContract".to_string(),
             TOKEN_MANAGER_CONTRACT.to_string(),
         ),
-        SystemContractName::new(
-            "CrossChainContract".to_string(),
-            CROSS_CHAIN_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("CrossChainContract".to_string(), CROSS_CHAIN_CONTRACT.to_string()),
         SystemContractName::new("StakingContract".to_string(), STAKING_CONTRACT.to_string()),
-        SystemContractName::new(
-            "StakeHubContract".to_string(),
-            STAKE_HUB_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("StakeHubContract".to_string(), STAKE_HUB_CONTRACT.to_string()),
         SystemContractName::new(
             "StakeCreditContract".to_string(),
             STAKE_CREDIT_CONTRACT.to_string(),
         ),
-        SystemContractName::new(
-            "GovTokenContract".to_string(),
-            GOV_TOKEN_CONTRACT.to_string(),
-        ),
-        SystemContractName::new(
-            "GovernorContract".to_string(),
-            GOVERNOR_CONTRACT.to_string(),
-        ),
-        SystemContractName::new(
-            "TimelockContract".to_string(),
-            TIMELOCK_CONTRACT.to_string(),
-        ),
+        SystemContractName::new("GovTokenContract".to_string(), GOV_TOKEN_CONTRACT.to_string()),
+        SystemContractName::new("GovernorContract".to_string(), GOVERNOR_CONTRACT.to_string()),
+        SystemContractName::new("TimelockContract".to_string(), TIMELOCK_CONTRACT.to_string()),
         SystemContractName::new(
             "TokenRecoverPortalContract".to_string(),
             TOKEN_RECOVER_PORTAL_CONTRACT.to_string(),
@@ -429,8 +381,8 @@ where
 {
     let mut m = HashMap::new();
     for (fork, condition) in spec.forks_iter() {
-        if condition.transitions_at_block(block_number)
-            || condition.transitions_at_timestamp(block_time, parent_block_time)
+        if condition.transitions_at_block(block_number) ||
+            condition.transitions_at_timestamp(block_time, parent_block_time)
         {
             if let Ok(contracts) = get_system_contract_codes(spec, fork.name()) {
                 for (k, v) in &contracts {


### PR DESCRIPTION
Changes in the PR:

1. Bump reth to latest commit
2. Fix rlp implementation of `NewBlock` requests by using new AT from https://github.com/paradigmxyz/reth/pull/16627
3. Remove unnecesary `PayloadTypes` generic from `Blockimport` type
4. Add a hack to configure the `ImportService` by sending the engine handle after node startup