### PR TITLE
feat: integrate `BscPrimitives`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod consensus;
 mod evm;
 mod hardforks;
 pub mod node;
+pub use node::primitives::{BscBlock, BscBlockBody, BscPrimitives};
 mod system_contracts;

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -1,6 +1,8 @@
 use crate::{
     chainspec::{parser::BscChainSpecParser, BscChainSpec},
-    node::{consensus::BscConsensus, evm::config::BscEvmConfig, BscNode},
+    node::{
+        consensus::BscConsensus, evm::config::BscEvmConfig, network::BscNetworkPrimitives, BscNode,
+    },
 };
 use clap::Parser;
 use reth::{
@@ -15,7 +17,6 @@ use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{launcher::FnLauncher, node::NoArgs};
 use reth_db::DatabaseEnv;
-use reth_network::EthNetworkPrimitives;
 use reth_tracing::FileWorkerGuard;
 use std::{
     fmt::{self},
@@ -89,10 +90,10 @@ where
             Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Db(command) => runner.run_blocking_until_ctrl_c(command.execute::<BscNode>()),
             Commands::Stage(command) => runner.run_command_until_exit(|ctx| {
-                command.execute::<BscNode, _, _, EthNetworkPrimitives>(ctx, components)
+                command.execute::<BscNode, _, _, BscNetworkPrimitives>(ctx, components)
             }),
             Commands::P2P(command) => {
-                runner.run_until_ctrl_c(command.execute::<EthNetworkPrimitives>())
+                runner.run_until_ctrl_c(command.execute::<BscNetworkPrimitives>())
             }
             Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
             Commands::Recover(command) => {

--- a/src/node/consensus.rs
+++ b/src/node/consensus.rs
@@ -1,11 +1,11 @@
-use crate::{chainspec::BscChainSpec, hardforks::BscHardforks};
+use crate::{hardforks::BscHardforks, node::BscNode, BscPrimitives};
 use reth::{
-    api::{FullNodeTypes, NodeTypes},
+    api::FullNodeTypes,
     builder::{components::ConsensusBuilder, BuilderContext},
     consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator},
 };
 use reth_chainspec::EthChainSpec;
-use reth_primitives::{EthPrimitives, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
+use reth_primitives::{NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader};
 use reth_primitives_traits::{Block, BlockHeader};
 use reth_provider::BlockExecutionResult;
 use std::sync::Arc;
@@ -17,9 +17,9 @@ pub struct BscConsensusBuilder;
 
 impl<Node> ConsensusBuilder<Node> for BscConsensusBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = BscChainSpec, Primitives = EthPrimitives>>,
+    Node: FullNodeTypes<Types = BscNode>,
 {
-    type Consensus = Arc<dyn FullConsensus<EthPrimitives, Error = ConsensusError>>;
+    type Consensus = Arc<dyn FullConsensus<BscPrimitives, Error = ConsensusError>>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
         Ok(Arc::new(BscConsensus::new(ctx.chain_spec())))

--- a/src/node/engine.rs
+++ b/src/node/engine.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use crate::{
+    node::{rpc::engine_api::payload::BscPayloadTypes, BscNode},
+    BscBlock, BscPrimitives,
+};
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::U256;
+use reth::{
+    api::FullNodeTypes,
+    builder::{components::PayloadServiceBuilder, BuilderContext},
+    payload::{PayloadBuilderHandle, PayloadServiceCommand},
+    transaction_pool::TransactionPool,
+};
+use reth_evm::ConfigureEvm;
+use reth_payload_primitives::BuiltPayload;
+use reth_primitives::SealedBlock;
+use tokio::sync::{broadcast, mpsc};
+use tracing::warn;
+
+/// Built payload for BSC. This is similar to [`EthBuiltPayload`] but without sidecars as those
+/// included into [`BscBlock`].
+#[derive(Debug, Clone)]
+pub struct BscBuiltPayload {
+    /// The built block
+    pub(crate) block: Arc<SealedBlock<BscBlock>>,
+    /// The fees of the block
+    pub(crate) fees: U256,
+    /// The requests of the payload
+    pub(crate) requests: Option<Requests>,
+}
+
+impl BuiltPayload for BscBuiltPayload {
+    type Primitives = BscPrimitives;
+
+    fn block(&self) -> &SealedBlock<BscBlock> {
+        self.block.as_ref()
+    }
+
+    fn fees(&self) -> U256 {
+        self.fees
+    }
+
+    fn requests(&self) -> Option<Requests> {
+        self.requests.clone()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct BscPayloadServiceBuilder;
+
+impl<Node, Pool, Evm> PayloadServiceBuilder<Node, Pool, Evm> for BscPayloadServiceBuilder
+where
+    Node: FullNodeTypes<Types = BscNode>,
+    Pool: TransactionPool,
+    Evm: ConfigureEvm,
+{
+    async fn spawn_payload_builder_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        _pool: Pool,
+        _evm_config: Evm,
+    ) -> eyre::Result<PayloadBuilderHandle<BscPayloadTypes>> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        ctx.task_executor().spawn_critical("payload builder", async move {
+            let mut subscriptions = Vec::new();
+
+            while let Some(message) = rx.recv().await {
+                match message {
+                    PayloadServiceCommand::Subscribe(tx) => {
+                        let (events_tx, events_rx) = broadcast::channel(100);
+                        // Retain senders to make sure that channels are not getting closed
+                        subscriptions.push(events_tx);
+                        let _ = tx.send(events_rx);
+                    }
+                    message => warn!(?message, "Noop payload service received a message"),
+                }
+            }
+        });
+
+        Ok(PayloadBuilderHandle::new(tx))
+    }
+}
+
+// impl From<EthBuiltPayload> for BscBuiltPayload {
+//     fn from(value: EthBuiltPayload) -> Self {
+//         let EthBuiltPayload { id, block, fees, sidecars, requests } = value;
+//         BscBuiltPayload {
+//             id,
+//             block: block.into(),
+//             fees,
+//             requests,
+//         }
+//     }
+// }
+
+// pub struct BscPayloadBuilder<Inner> {
+//     inner: Inner,
+// }
+
+// impl<Inner> PayloadBuilder for BscPayloadBuilder<Inner>
+// where
+//     Inner: PayloadBuilder<BuiltPayload = EthBuiltPayload>,
+// {
+//     type Attributes = Inner::Attributes;
+//     type BuiltPayload = BscBuiltPayload;
+//     type Error = Inner::Error;
+
+//     fn try_build(
+//         &self,
+//         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+//     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
+//         let outcome = self.inner.try_build(args)?;
+//     }
+// }

--- a/src/node/evm/assembler.rs
+++ b/src/node/evm/assembler.rs
@@ -1,0 +1,31 @@
+use crate::{
+    node::evm::config::{BscBlockExecutorFactory, BscEvmConfig},
+    BscBlock, BscBlockBody,
+};
+use alloy_consensus::{Block, Header};
+use reth_evm::{
+    block::BlockExecutionError,
+    execute::{BlockAssembler, BlockAssemblerInput},
+};
+
+impl BlockAssembler<BscBlockExecutorFactory> for BscEvmConfig {
+    type Block = BscBlock;
+
+    fn assemble_block(
+        &self,
+        input: BlockAssemblerInput<'_, '_, BscBlockExecutorFactory, Header>,
+    ) -> Result<Self::Block, BlockExecutionError> {
+        let Block { header, body: inner } = self.block_assembler.assemble_block(input)?;
+        Ok(BscBlock {
+            header,
+            body: BscBlockBody {
+                inner,
+                // HACK: we're setting sidecars to `None` here but ideally we should somehow get
+                // them from the payload builder.
+                //
+                // Payload building is out of scope of reth-bsc for now, so this is not critical
+                sidecars: None,
+            },
+        })
+    }
+}

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -1,20 +1,19 @@
 use crate::{
-    chainspec::BscChainSpec,
     evm::{
         api::{ctx::BscContext, BscEvmInner},
         precompiles::BscPrecompiles,
         spec::BscSpecId,
         transaction::{BscTxEnv, BscTxTr},
     },
+    node::BscNode,
 };
 use alloy_primitives::{Address, Bytes};
 use config::BscEvmConfig;
 use reth::{
-    api::{FullNodeTypes, NodeTypes},
+    api::FullNodeTypes,
     builder::{components::ExecutorBuilder, BuilderContext},
 };
 use reth_evm::{Evm, EvmEnv};
-use reth_primitives::EthPrimitives;
 use revm::{
     context::{
         result::{EVMError, HaltReason, ResultAndState},
@@ -26,6 +25,7 @@ use revm::{
 };
 use std::ops::{Deref, DerefMut};
 
+mod assembler;
 pub mod config;
 mod executor;
 mod factory;
@@ -171,7 +171,7 @@ pub struct BscExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for BscExecutorBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = BscChainSpec, Primitives = EthPrimitives>>,
+    Node: FullNodeTypes<Types = BscNode>,
 {
     type EVM = BscEvmConfig;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,34 +1,44 @@
-use std::sync::Arc;
-
-use crate::{chainspec::BscChainSpec, node::rpc::BscEthApiBuilder};
-
-use crate::node::rpc::engine_api::{
-    builder::BscEngineApiBuilder, payload::BscPayloadTypes, validator::BscEngineValidatorBuilder,
+use crate::{
+    chainspec::BscChainSpec,
+    node::{
+        primitives::BscPrimitives,
+        rpc::{
+            engine_api::{
+                builder::BscEngineApiBuilder, payload::BscPayloadTypes,
+                validator::BscEngineValidatorBuilder,
+            },
+            BscEthApiBuilder,
+        },
+        storage::BscStorage,
+    },
+    BscBlock, BscBlockBody,
 };
 use consensus::BscConsensusBuilder;
+use engine::BscPayloadServiceBuilder;
 use evm::BscExecutorBuilder;
 use network::BscNetworkBuilder;
 use reth::{
     api::{FullNodeComponents, FullNodeTypes, NodeTypes},
     builder::{
-        components::{BasicPayloadServiceBuilder, ComponentsBuilder},
-        rpc::RpcAddOns,
-        DebugNode, Node, NodeAdapter, NodeComponentsBuilder,
+        components::ComponentsBuilder, rpc::RpcAddOns, DebugNode, Node, NodeAdapter,
+        NodeComponentsBuilder,
     },
 };
 use reth_engine_primitives::BeaconConsensusEngineHandle;
-use reth_node_ethereum::node::{EthereumPayloadBuilder, EthereumPoolBuilder};
-use reth_primitives::{Block, BlockBody, EthPrimitives};
-use reth_provider::EthStorage;
+use reth_node_ethereum::node::EthereumPoolBuilder;
+use reth_primitives::BlockBody;
 use reth_trie_db::MerklePatriciaTrie;
+use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex};
 
 pub mod cli;
 pub mod consensus;
+pub mod engine;
 pub mod evm;
 pub mod network;
 pub mod primitives;
 pub mod rpc;
+pub mod storage;
 
 /// Bsc addons configuring RPC types
 pub type BscNodeAddOns<N> =
@@ -54,28 +64,30 @@ impl BscNode {
     ) -> ComponentsBuilder<
         Node,
         EthereumPoolBuilder,
-        BasicPayloadServiceBuilder<EthereumPayloadBuilder>,
+        BscPayloadServiceBuilder,
         BscNetworkBuilder,
         BscExecutorBuilder,
         BscConsensusBuilder,
     >
     where
-        Node: FullNodeTypes<
-            Types: NodeTypes<
-                Payload = BscPayloadTypes,
-                ChainSpec = BscChainSpec,
-                Primitives = EthPrimitives,
-            >,
-        >,
+        Node: FullNodeTypes<Types = Self>,
     {
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(EthereumPoolBuilder::default())
             .executor(BscExecutorBuilder::default())
-            .payload(BasicPayloadServiceBuilder::default())
+            .payload(BscPayloadServiceBuilder::default())
             .network(BscNetworkBuilder { engine_handle_rx: self.engine_handle_rx.clone() })
             .consensus(BscConsensusBuilder::default())
     }
+}
+
+impl NodeTypes for BscNode {
+    type Primitives = BscPrimitives;
+    type ChainSpec = BscChainSpec;
+    type StateCommitment = MerklePatriciaTrie;
+    type Storage = BscStorage;
+    type Payload = BscPayloadTypes;
 }
 
 impl<N> Node<N> for BscNode
@@ -85,7 +97,7 @@ where
     type ComponentsBuilder = ComponentsBuilder<
         N,
         EthereumPoolBuilder,
-        BasicPayloadServiceBuilder<EthereumPayloadBuilder>,
+        BscPayloadServiceBuilder,
         BscNetworkBuilder,
         BscExecutorBuilder,
         BscConsensusBuilder,
@@ -110,26 +122,21 @@ where
 {
     type RpcBlock = alloy_rpc_types::Block;
 
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> Block {
+    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> BscBlock {
         let alloy_rpc_types::Block { header, transactions, withdrawals, .. } = rpc_block;
-        Block {
+        BscBlock {
             header: header.inner,
-            body: BlockBody {
-                transactions: transactions
-                    .into_transactions()
-                    .map(|tx| tx.inner.into_inner().into())
-                    .collect(),
-                ommers: Default::default(),
-                withdrawals,
+            body: BscBlockBody {
+                inner: BlockBody {
+                    transactions: transactions
+                        .into_transactions()
+                        .map(|tx| tx.inner.into_inner().into())
+                        .collect(),
+                    ommers: Default::default(),
+                    withdrawals,
+                },
+                sidecars: None,
             },
         }
     }
-}
-
-impl NodeTypes for BscNode {
-    type Primitives = EthPrimitives;
-    type ChainSpec = BscChainSpec;
-    type StateCommitment = MerklePatriciaTrie;
-    type Storage = EthStorage;
-    type Payload = BscPayloadTypes;
 }

--- a/src/node/primitives.rs
+++ b/src/node/primitives.rs
@@ -32,9 +32,21 @@ pub struct BscBlobTransactionSidecar {
 
 /// Block body for BSC. It is equivalent to Ethereum [`BlockBody`] but additionally stores sidecars
 /// for blob transactions.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    derive_more::Deref,
+    derive_more::DerefMut,
+)]
 pub struct BscBlockBody {
     #[serde(flatten)]
+    #[deref]
+    #[deref_mut]
     pub inner: BlockBody,
     pub sidecars: Option<Vec<BscBlobTransactionSidecar>>,
 }

--- a/src/node/rpc/block.rs
+++ b/src/node/rpc/block.rs
@@ -1,13 +1,14 @@
 use crate::{
     chainspec::BscChainSpec,
     node::rpc::{BscEthApi, BscNodeCore},
+    BscBlock, BscPrimitives,
 };
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use reth::{
     api::NodeTypes,
     builder::FullNodeComponents,
-    primitives::{Block, Receipt, SealedHeader, TransactionMeta, TransactionSigned},
+    primitives::{Receipt, SealedHeader, TransactionMeta, TransactionSigned},
     providers::{BlockReaderIdExt, ProviderHeader, ReceiptProvider, TransactionsProvider},
     rpc::{
         eth::EthApiTypes,
@@ -18,7 +19,6 @@ use reth::{
 };
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
-use reth_primitives::EthPrimitives;
 use reth_primitives_traits::BlockBody as _;
 use reth_provider::{
     BlockReader, ChainSpecProvider, HeaderProvider, ProviderBlock, ProviderReceipt, ProviderTx,
@@ -106,13 +106,13 @@ where
     N: RpcNodeCore<
         Provider: BlockReaderIdExt<
             Transaction = TransactionSigned,
-            Block = Block,
+            Block = BscBlock,
             Receipt = Receipt,
             Header = alloy_consensus::Header,
         > + ChainSpecProvider<ChainSpec: EthChainSpec + EthereumHardforks>
                       + StateProviderFactory,
         Pool: TransactionPool<Transaction: PoolTransaction<Consensus = ProviderTx<N::Provider>>>,
-        Evm: ConfigureEvm<Primitives = EthPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
+        Evm: ConfigureEvm<Primitives = BscPrimitives, NextBlockEnvCtx = NextBlockEnvAttributes>,
     >,
 {
     #[inline]

--- a/src/node/rpc/engine_api/builder.rs
+++ b/src/node/rpc/engine_api/builder.rs
@@ -1,11 +1,8 @@
 use super::BscEngineApi;
-use crate::node::rpc::engine_api::validator::BscExecutionData;
 use reth::{
-    api::{AddOnsContext, FullNodeComponents, NodeTypes},
+    api::{AddOnsContext, FullNodeComponents},
     builder::rpc::EngineApiBuilder,
-    primitives::EthereumHardforks,
 };
-use reth_engine_primitives::EngineTypes;
 
 /// Builder for mocked [`BscEngineApi`] implementation.
 #[derive(Debug, Default)]
@@ -13,12 +10,7 @@ pub struct BscEngineApiBuilder;
 
 impl<N> EngineApiBuilder<N> for BscEngineApiBuilder
 where
-    N: FullNodeComponents<
-        Types: NodeTypes<
-            ChainSpec: EthereumHardforks,
-            Payload: EngineTypes<ExecutionData = BscExecutionData>,
-        >,
-    >,
+    N: FullNodeComponents,
 {
     type EngineApi = BscEngineApi;
 

--- a/src/node/rpc/engine_api/payload.rs
+++ b/src/node/rpc/engine_api/payload.rs
@@ -1,13 +1,8 @@
-use crate::node::rpc::engine_api::validator::BscExecutionData;
-use alloy_rpc_types_engine::{
-    ExecutionPayloadEnvelopeV2, ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4,
-    ExecutionPayloadEnvelopeV5, ExecutionPayloadV1,
-};
+use crate::node::{engine::BscBuiltPayload, rpc::engine_api::validator::BscExecutionData};
 use reth::{
-    payload::{EthBuiltPayload, EthPayloadBuilderAttributes},
+    payload::EthPayloadBuilderAttributes,
     primitives::{NodePrimitives, SealedBlock},
 };
-use reth_engine_primitives::EngineTypes;
 use reth_node_ethereum::engine::EthPayloadAttributes;
 use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 
@@ -17,7 +12,7 @@ use reth_payload_primitives::{BuiltPayload, PayloadTypes};
 pub struct BscPayloadTypes;
 
 impl PayloadTypes for BscPayloadTypes {
-    type BuiltPayload = EthBuiltPayload;
+    type BuiltPayload = BscBuiltPayload;
     type PayloadAttributes = EthPayloadAttributes;
     type PayloadBuilderAttributes = EthPayloadBuilderAttributes;
     type ExecutionData = BscExecutionData;
@@ -29,12 +24,4 @@ impl PayloadTypes for BscPayloadTypes {
     ) -> Self::ExecutionData {
         BscExecutionData(block.into_block())
     }
-}
-
-impl EngineTypes for BscPayloadTypes {
-    type ExecutionPayloadEnvelopeV1 = ExecutionPayloadV1;
-    type ExecutionPayloadEnvelopeV2 = ExecutionPayloadEnvelopeV2;
-    type ExecutionPayloadEnvelopeV3 = ExecutionPayloadEnvelopeV3;
-    type ExecutionPayloadEnvelopeV4 = ExecutionPayloadEnvelopeV4;
-    type ExecutionPayloadEnvelopeV5 = ExecutionPayloadEnvelopeV5;
 }

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -6,7 +6,7 @@ use reth::{
         FullNodeComponents,
     },
     chainspec::EthChainSpec,
-    primitives::{EthPrimitives, EthereumHardforks},
+    primitives::EthereumHardforks,
     providers::ChainSpecProvider,
     rpc::{
         eth::{DevSigner, FullEthApiServer},
@@ -34,6 +34,8 @@ use reth_rpc_eth_api::{
     EthApiTypes, FromEvmError, RpcNodeCore, RpcNodeCoreExt,
 };
 use std::{fmt, sync::Arc};
+
+use crate::BscPrimitives;
 
 mod block;
 mod call;
@@ -81,7 +83,7 @@ impl<N> RpcNodeCore for BscEthApi<N>
 where
     N: BscNodeCore,
 {
-    type Primitives = EthPrimitives;
+    type Primitives = BscPrimitives;
     type Provider = N::Provider;
     type Pool = N::Pool;
     type Evm = <N as RpcNodeCore>::Evm;

--- a/src/node/rpc/transaction.rs
+++ b/src/node/rpc/transaction.rs
@@ -1,5 +1,5 @@
 use super::BscNodeCore;
-use crate::node::rpc::BscEthApi;
+use crate::{node::rpc::BscEthApi, BscPrimitives};
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Bytes, Signature, B256};
 use reth::{
@@ -13,7 +13,6 @@ use reth::{
     },
     transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool},
 };
-use reth_primitives::EthPrimitives;
 use reth_provider::{BlockReader, BlockReaderIdExt, ProviderTx, TransactionsProvider};
 use reth_rpc_eth_api::{
     helpers::{EthSigner, EthTransactions, LoadTransaction, SpawnBlocking},
@@ -31,7 +30,7 @@ impl<N> TransactionCompat for BscEthApi<N>
 where
     N: FullNodeComponents<Provider: ReceiptProvider<Receipt = Receipt>>,
 {
-    type Primitives = EthPrimitives;
+    type Primitives = BscPrimitives;
     type Transaction = <Ethereum as Network>::TransactionResponse;
 
     type Error = EthApiError;

--- a/src/node/storage.rs
+++ b/src/node/storage.rs
@@ -1,0 +1,94 @@
+use crate::{BscBlock, BscBlockBody, BscPrimitives};
+use reth_chainspec::EthereumHardforks;
+use reth_db::transaction::{DbTx, DbTxMut};
+use reth_provider::{
+    providers::{ChainStorage, NodeTypesForProvider},
+    BlockBodyReader, BlockBodyWriter, ChainSpecProvider, ChainStorageReader, ChainStorageWriter,
+    DBProvider, DatabaseProvider, EthStorage, ProviderResult, ReadBodyInput, StorageLocation,
+};
+
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct BscStorage(EthStorage);
+
+impl<Provider> BlockBodyWriter<Provider, BscBlockBody> for BscStorage
+where
+    Provider: DBProvider<Tx: DbTxMut>,
+{
+    fn write_block_bodies(
+        &self,
+        provider: &Provider,
+        bodies: Vec<(u64, Option<BscBlockBody>)>,
+        write_to: StorageLocation,
+    ) -> ProviderResult<()> {
+        let (eth_bodies, _sidecars) = bodies
+            .into_iter()
+            .map(|(block_number, body)| {
+                if let Some(BscBlockBody { inner, sidecars }) = body {
+                    ((block_number, Some(inner)), (block_number, Some(sidecars)))
+                } else {
+                    ((block_number, None), (block_number, None))
+                }
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+        self.0.write_block_bodies(provider, eth_bodies, write_to)?;
+
+        // TODO: Write sidecars
+
+        Ok(())
+    }
+
+    fn remove_block_bodies_above(
+        &self,
+        provider: &Provider,
+        block: u64,
+        remove_from: StorageLocation,
+    ) -> ProviderResult<()> {
+        self.0.remove_block_bodies_above(provider, block, remove_from)?;
+
+        // TODO: Remove sidecars
+
+        Ok(())
+    }
+}
+
+impl<Provider> BlockBodyReader<Provider> for BscStorage
+where
+    Provider: DBProvider + ChainSpecProvider<ChainSpec: EthereumHardforks>,
+{
+    type Block = BscBlock;
+
+    fn read_block_bodies(
+        &self,
+        provider: &Provider,
+        inputs: Vec<ReadBodyInput<'_, Self::Block>>,
+    ) -> ProviderResult<Vec<BscBlockBody>> {
+        let eth_bodies = self.0.read_block_bodies(provider, inputs)?;
+
+        // TODO: Read sidecars
+
+        Ok(eth_bodies.into_iter().map(|inner| BscBlockBody { inner, sidecars: None }).collect())
+    }
+}
+
+impl ChainStorage<BscPrimitives> for BscStorage {
+    fn reader<TX, Types>(
+        &self,
+    ) -> impl ChainStorageReader<DatabaseProvider<TX, Types>, BscPrimitives>
+    where
+        TX: DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = BscPrimitives>,
+    {
+        self
+    }
+
+    fn writer<TX, Types>(
+        &self,
+    ) -> impl ChainStorageWriter<DatabaseProvider<TX, Types>, BscPrimitives>
+    where
+        TX: DbTxMut + DbTx + 'static,
+        Types: NodeTypesForProvider<Primitives = BscPrimitives>,
+    {
+        self
+    }
+}


### PR DESCRIPTION
This PR makes it possible to download latest bsc blocks from the network thus enabling live sync

Changes in the PR and TODOs:
1. `BscStorage` is introduced. For now it's just a wrapper around `EthStorage` but eventually it's supposed to also write sidecars to database.
2. `ImportService` is changed to not return block import errors on `Syncing` FCU/newPayload responses or other errors unrelated to block validity. Earlier this resulted in us disconnecting from all PRs because of `BadBlock` errors which were actually just us lacking the state.
3. `ImportService` is changed to also set the received head block hash as finalized/safe hashes to make our engine handle it correctly. This is fine while we're debugging but eventually we should find how the actual finalized hash should be derived.
4. `BscPayloadServiceBuilder` and `BscBuiltPayload` are introduced to satisfy payload bounds. `BscPayloadServiceBuilder` is a noop for now because we don't support validating nodes yet. It can be upstreamed to reth as `NoopPayloadServiceBuilder`.

