### PR TITLE
fix: block rewards as end of block

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -398,12 +398,12 @@ where
             self.deploy_feynman_contracts(self.evm.block().beneficiary)?;
         }
 
-        self.distribute_block_rewards(self.evm.block().beneficiary)?;
-
         let system_txs = self.system_txs.clone();
         for tx in system_txs {
             self.handle_slash_tx(&tx)?;
         }
+
+        self.distribute_block_rewards(self.evm.block().beneficiary)?;
 
         // TODO:
         // Consensus: Slash validator if not in turn


### PR DESCRIPTION
Block rewards system txs should be created at the end of block and slash txs right before.