### PR TITLE
Fix/hertz gas validation

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -392,8 +392,6 @@ where
             return Ok(0);
         }
 
-        self.validate_hertz_gas(tx)?;
-
         // apply patches before
         patch_mainnet_before_tx(tx.tx(), self.evm.db_mut())?;
 

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -314,26 +314,6 @@ where
         self.transact_system_tx(&tx, validator)?;
         Ok(())
     }
-
-    /// Validates the gas price of the transaction is equal to the max fee per gas.
-    /// This is only relevant for the Hertz hardfork.
-    /// <https://www.bnbchain.org/en/blog/announcing-v1-2-9-a-significant-hard-fork-release-for-bsc-mainnet>
-    fn validate_hertz_gas(
-        &mut self,
-        tx: impl ExecutableTx<Self>,
-    ) -> Result<(), BlockExecutionError> {
-        if self.spec.is_hertz_active_at_block(self.evm.block().number) {
-            if let Some(prio_fee) = tx.tx().max_priority_fee_per_gas() {
-                if prio_fee != tx.tx().max_fee_per_gas() {
-                    return Err(BlockExecutionError::msg(
-                        "Priority fee is not equal to max fee per gas",
-                    ));
-                }
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl<'a, DB, E, Spec, R> BlockExecutor for BscBlockExecutor<'a, E, Spec, R>


### PR DESCRIPTION
Removing gas validation that was preventing some tx to be executed on Hertz blocks.