### PR TITLE
fix: add update-validatorsetv2 tx

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -272,6 +272,8 @@ where
         Ok(())
     }
 
+     /// Handle update validatorsetv2 system tx.
+     /// Activated by <https://github.com/bnb-chain/BEPs/pull/294>
     fn handle_update_validator_set_v2_tx(&mut self, tx: &TransactionSigned) -> Result<(), BlockExecutionError> {
         sol!(
             function updateValidatorSetV2(
@@ -282,10 +284,10 @@ where
         );
 
         let input = tx.input();
-        let is_update_validator_set_tx =
+        let is_update_validator_set_v2_tx =
             input.len() >= 4 && input[..4] == updateValidatorSetV2Call::SELECTOR;
 
-        if is_update_validator_set_tx {
+        if is_update_validator_set_v2_tx {
             let signer = tx.recover_signer().map_err(BlockExecutionError::other)?;
             self.transact_system_tx(tx, signer)?;
         }
@@ -476,7 +478,7 @@ where
             }
         }
 
-        // TODO: refine later
+        // TODO: add breathe check and polish it later.
         let system_txs_v2 = self.system_txs.clone();
         for tx in &system_txs_v2 {
             self.handle_update_validator_set_v2_tx(tx)?;

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -272,6 +272,27 @@ where
         Ok(())
     }
 
+    fn handle_update_validator_set_v2_tx(&mut self, tx: &TransactionSigned) -> Result<(), BlockExecutionError> {
+        sol!(
+            function updateValidatorSetV2(
+                address[] _consensusAddrs,
+                uint64[] _votingPowers,
+                bytes[] _voteAddrs
+            );
+        );
+
+        let input = tx.input();
+        let is_update_validator_set_tx =
+            input.len() >= 4 && input[..4] == updateValidatorSetV2Call::SELECTOR;
+
+        if is_update_validator_set_tx {
+            let signer = tx.recover_signer().map_err(BlockExecutionError::other)?;
+            self.transact_system_tx(tx, signer)?;
+        }
+
+        Ok(())
+    }
+
     /// Distributes block rewards to the validator.
     fn distribute_block_rewards(&mut self, validator: Address) -> Result<(), BlockExecutionError> {
         let system_account = self
@@ -455,9 +476,14 @@ where
             }
         }
 
+        // TODO: refine later
+        let system_txs_v2 = self.system_txs.clone();
+        for tx in &system_txs_v2 {
+            self.handle_update_validator_set_v2_tx(tx)?;
+        }
+
         // TODO:
         // Consensus: Slash validator if not in turn
-        // Consensus: Update validator set
 
         Ok((
             self.evm,


### PR DESCRIPTION
### Description

Add update validatorsetv2 tx to ensure stage sync can pass Feynman hardfork block height.

### Rationale

Refer to: https://github.com/bnb-chain/BEPs/pull/294 and https://github.com/bnb-chain/reth-bsc-trail/blob/89efacfa3ef4f134ba2d468154cb6fdee9681a95/crates/bsc/evm/src/post_execution.rs#L423.

### Example

N/A.


### Changes

Notable changes: 
* Node evm execute system tx.
