### PR TITLE
Fix Cancun activation on BSC testnet

### DIFF
--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -165,12 +165,14 @@ impl BscHardfork {
             |fork| match fork {
                 EthereumHardfork::Shanghai => Some(1705996800),
                 EthereumHardfork::Cancun => Some(1718863500),
+                EthereumHardfork::Prague => Some(1742436600),
                 _ => None,
             },
             |fork| match fork {
                 Self::Kepler => Some(1705996800),
                 Self::Feynman | Self::FeynmanFix => Some(1713419340),
                 Self::Haber => Some(1718863500),
+                Self::HaberFix => Some(1727316120),
                 _ => None,
             },
         )
@@ -183,6 +185,7 @@ impl BscHardfork {
             |fork| match fork {
                 EthereumHardfork::Shanghai => Some(1702972800),
                 EthereumHardfork::Cancun => Some(1713330442),
+                EthereumHardfork::Prague => Some(1740452880),
                 _ => None,
             },
             |fork| match fork {
@@ -360,12 +363,8 @@ impl From<BscHardfork> for SpecId {
             BscHardfork::Kepler | BscHardfork::Feynman | BscHardfork::FeynmanFix => {
                 SpecId::SHANGHAI
             }
-            BscHardfork::Haber |
-            BscHardfork::HaberFix |
-            BscHardfork::Bohr |
-            BscHardfork::Pascal |
-            BscHardfork::Lorentz |
-            BscHardfork::Maxwell => SpecId::CANCUN,
+            BscHardfork::Haber | BscHardfork::HaberFix | BscHardfork::Bohr => SpecId::CANCUN,
+            BscHardfork::Pascal | BscHardfork::Lorentz | BscHardfork::Maxwell => SpecId::PRAGUE,
         }
     }
 }
@@ -382,7 +381,7 @@ mod tests {
             BscHardfork::bsc_mainnet_activation_timestamp(EthereumHardfork::Cancun),
             Some(1718863500)
         );
-        assert_eq!(BscHardfork::bsc_mainnet_activation_timestamp(BscHardfork::HaberFix), None);
+        assert_eq!(BscHardfork::bsc_mainnet_activation_timestamp(BscHardfork::HaberFix), Some(1727316120));
     }
 
     #[test]
@@ -400,7 +399,7 @@ mod tests {
 
         // Test mainnet chain spec
         let mainnet_spec = crate::chainspec::BscChainSpec::from(bsc_mainnet());
-        
+
         // Test blocks around the critical transition points
         // Block 23846000: Should be Moran (before Gibbs activation)
         assert_eq!(
@@ -444,7 +443,7 @@ mod tests {
 
         // Test testnet chain spec
         let testnet_spec = crate::chainspec::BscChainSpec::from(bsc_testnet());
-        
+
         // Test blocks around the critical transition points for testnet
         // Block 23603939: Should be Nano (before Moran activation)
         assert_eq!(

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -318,8 +318,8 @@ pub fn revm_spec_by_timestamp_and_block_number(
         BscHardfork::Bohr
     } else if chain_spec.is_haber_fix_active_at_timestamp(timestamp) {
         BscHardfork::HaberFix
-    } else if chain_spec.is_haber_active_at_timestamp(timestamp) {
-        BscHardfork::Haber
+    } else if chain_spec.is_haber_active_at_timestamp(timestamp) || chain_spec.is_cancun_active_at_timestamp(timestamp) {
+        BscHardfork::Haber // Both Haber and Cancun map to SpecId::CANCUN, handle testnet case where Cancun activates before Haber
     } else if chain_spec.is_feynman_fix_active_at_timestamp(timestamp) {
         BscHardfork::FeynmanFix
     } else if chain_spec.is_feynman_active_at_timestamp(timestamp) {


### PR DESCRIPTION
On BSC testnet Cancun activate before Harber, so we need to add a condition to map it correctly 