### PR TITLE
add release and maxperf profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,16 @@ client = [
     "jsonrpsee/async-client",
     "reth-rpc-eth-api/client",
 ]
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+debug = "none"
+strip = "symbols"
+panic = "unwind"
+codegen-units = 16
+
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
refer to https://reth.rs/installation/source/#optimizations


- maxperf: default for binary releases, enables aggressive optimisations including full LTO. Although compiling with this profile improves some benchmarks by around 20% compared to