### PR TITLE
fix: fix double_sign precompile return code

### DIFF
--- a/src/evm/precompiles/double_sign.rs
+++ b/src/evm/precompiles/double_sign.rs
@@ -102,22 +102,22 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
 
     // basic check
     if header1.number.to_be_bytes().len() > 32 || header2.number.to_be_bytes().len() > 32 {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
     if header1.number != header2.number {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
     if header1.parent_hash.cmp(&header2.parent_hash) != Ordering::Equal {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
 
     if header1.extra.len() < EXTRA_SEAL_LENGTH || header1.extra.len() < EXTRA_SEAL_LENGTH {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
     let sig1 = &header1.extra[header1.extra.len() - EXTRA_SEAL_LENGTH..];
     let sig2 = &header2.extra[header2.extra.len() - EXTRA_SEAL_LENGTH..];
     if sig1.eq(sig2) {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
 
     // check signature
@@ -125,7 +125,7 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
     let msg_hash2 = seal_hash(&header2, evidence.chain_id);
 
     if msg_hash1.eq(&msg_hash2) {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
 
     let recid1 = sig1[64];
@@ -147,7 +147,7 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
     };
 
     if !addr1.eq(&addr2) {
-        return Err(BscPrecompileError::Reverted(DOUBLE_SIGN_EVIDENCE_VALIDATION_BASE).into());
+        return Err(PrecompileError::other("invalid evidence").into());
     }
 
     let mut res = [0; 52];

--- a/src/evm/precompiles/double_sign.rs
+++ b/src/evm/precompiles/double_sign.rs
@@ -102,22 +102,22 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
 
     // basic check
     if header1.number.to_be_bytes().len() > 32 || header2.number.to_be_bytes().len() > 32 {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
     if header1.number != header2.number {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
     if header1.parent_hash.cmp(&header2.parent_hash) != Ordering::Equal {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
 
     if header1.extra.len() < EXTRA_SEAL_LENGTH || header1.extra.len() < EXTRA_SEAL_LENGTH {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
     let sig1 = &header1.extra[header1.extra.len() - EXTRA_SEAL_LENGTH..];
     let sig2 = &header2.extra[header2.extra.len() - EXTRA_SEAL_LENGTH..];
     if sig1.eq(sig2) {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
 
     // check signature
@@ -125,7 +125,7 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
     let msg_hash2 = seal_hash(&header2, evidence.chain_id);
 
     if msg_hash1.eq(&msg_hash2) {
-        return Err(PrecompileError::other("invalid evidence"));
+        return Err(BscPrecompileError::DoubleSignInvalidEvidence.into());
     }
 
     let recid1 = sig1[64];

--- a/src/evm/precompiles/double_sign.rs
+++ b/src/evm/precompiles/double_sign.rs
@@ -102,22 +102,22 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
 
     // basic check
     if header1.number.to_be_bytes().len() > 32 || header2.number.to_be_bytes().len() > 32 {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
     if header1.number != header2.number {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
     if header1.parent_hash.cmp(&header2.parent_hash) != Ordering::Equal {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
 
     if header1.extra.len() < EXTRA_SEAL_LENGTH || header1.extra.len() < EXTRA_SEAL_LENGTH {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
     let sig1 = &header1.extra[header1.extra.len() - EXTRA_SEAL_LENGTH..];
     let sig2 = &header2.extra[header2.extra.len() - EXTRA_SEAL_LENGTH..];
     if sig1.eq(sig2) {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
 
     // check signature
@@ -125,7 +125,7 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
     let msg_hash2 = seal_hash(&header2, evidence.chain_id);
 
     if msg_hash1.eq(&msg_hash2) {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
 
     let recid1 = sig1[64];
@@ -147,7 +147,7 @@ fn double_sign_evidence_validation_run(input: &[u8], gas_limit: u64) -> Precompi
     };
 
     if !addr1.eq(&addr2) {
-        return Err(PrecompileError::other("invalid evidence").into());
+        return Err(PrecompileError::other("invalid evidence"));
     }
 
     let mut res = [0; 52];

--- a/src/evm/precompiles/error.rs
+++ b/src/evm/precompiles/error.rs
@@ -13,21 +13,18 @@ pub enum BscPrecompileError {
     /// This is for BSC EVM compatibility specially.
     /// This error will not consume all gas but only the returned amount.
     Reverted(u64),
+    /// The double sing invalid evidence.
+    DoubleSignInvalidEvidence,
 }
 
 impl From<BscPrecompileError> for PrecompileError {
     fn from(error: BscPrecompileError) -> Self {
         match error {
-            BscPrecompileError::CometBftInvalidInput => {
-                PrecompileError::Other("invalid input".to_string())
-            }
-            BscPrecompileError::CometBftApplyBlockFailed => {
-                PrecompileError::Other("apply block failed".to_string())
-            }
-            BscPrecompileError::CometBftEncodeConsensusStateFailed => {
-                PrecompileError::Other("encode consensus state failed".to_string())
-            }
+            BscPrecompileError::CometBftInvalidInput => PrecompileError::Other("invalid input".to_string()),
+            BscPrecompileError::CometBftApplyBlockFailed => PrecompileError::Other("apply block failed".to_string()),
+            BscPrecompileError::CometBftEncodeConsensusStateFailed => PrecompileError::Other("encode consensus state failed".to_string()),
             BscPrecompileError::Reverted(gas) => PrecompileError::Other(format!("Reverted({gas})")),
+            BscPrecompileError::DoubleSignInvalidEvidence => PrecompileError::Other("invalid evidence".to_string()),
         }
     }
 }


### PR DESCRIPTION
### Description

Fix double_sign precompile return code.

### Rationale

Keep the same return code with 

https://github.com/bnb-chain/revm/blob/d66170e712460ae766fc26a063f106658ce33e9d/crates/precompile/src/double_sign.rs#L95-L108


### Example

Avoid this https://testnet.bscscan.com/tx/0x899592476081d65840828cc65b283c2835c15c6d9101c865dd5db07824bcd9bf execution inconsistency.

### Changes

Notable changes: 
* double sign precompile related.
