### PR TITLE
chore: enable serve historical block hashes from state 

### DIFF
--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -11,7 +11,7 @@ use revm::{
         result::{EVMError, ExecutionResult, ResultAndState},
         ContextTr,
     },
-    handler::{Handler, SystemCallEvm, SYSTEM_ADDRESS},
+    handler::{Handler, SystemCallEvm},
     inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler},
     state::EvmState,
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
@@ -87,10 +87,10 @@ where
 {
     fn transact_system_call(
         &mut self,
-        contract: Address,
-        data: Bytes,
+        _contract: Address,
+        _data: Bytes,
     ) -> Result<ExecutionResult, Self::Error> {
-        self.transact_system_call_with_caller(SYSTEM_ADDRESS, contract, data)
+        unimplemented!()
     }
 
     fn transact_system_call_with_caller(

--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -3,6 +3,7 @@ use crate::evm::{
     handler::BscHandler,
     transaction::BscTxEnv,
 };
+use alloy_primitives::{Address, Bytes};
 use reth_evm::Database;
 use revm::{
     context::{BlockEnv, ContextSetters},
@@ -10,7 +11,7 @@ use revm::{
         result::{EVMError, ExecutionResult, ResultAndState},
         ContextTr,
     },
-    handler::Handler,
+    handler::{Handler, SystemCallEvm, SYSTEM_ADDRESS},
     inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler},
     state::EvmState,
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
@@ -78,4 +79,52 @@ where
     DB: Database + DatabaseCommit,
     INSP: Inspector<BscContext<DB>>,
 {
+}
+
+impl<DB, INSP> SystemCallEvm for BscEvm<DB, INSP>
+where
+    DB: Database,
+{
+    fn transact_system_call(
+        &mut self,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ExecutionResult, Self::Error> {
+        self.transact_system_call_with_caller(SYSTEM_ADDRESS, contract, data)
+    }
+
+    fn transact_system_call_with_caller(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ExecutionResult, Self::Error> {
+        let tx = BscTxEnv {
+            base: revm::context::TxEnv {
+                caller,
+                kind: alloy_primitives::TxKind::Call(contract),
+                nonce: 0,
+                gas_limit: self.inner.ctx.block.gas_limit,
+                value: alloy_primitives::U256::ZERO,
+                data,
+                gas_price: 0,
+                chain_id: Some(self.inner.ctx.cfg.chain_id),
+                gas_priority_fee: None,
+                access_list: Default::default(),
+                blob_hashes: Vec::new(),
+                max_fee_per_blob_gas: 0,
+                tx_type: 0,
+                authorization_list: Default::default(),
+            },
+           is_system_transaction: true,
+        };
+        
+        // disable nonce check for system calls
+        let original_disable_nonce_check = self.inner.ctx.cfg.disable_nonce_check;
+        self.inner.ctx.cfg.disable_nonce_check = true;
+        let result = self.transact_one(tx);
+        self.inner.ctx.cfg.disable_nonce_check = original_disable_nonce_check;
+        
+        result
+    }
 }

--- a/src/hardforks/mod.rs
+++ b/src/hardforks/mod.rs
@@ -186,11 +186,10 @@ pub trait BscHardforks: EthereumHardforks {
         self.bsc_fork_activation(BscHardfork::Bohr).active_at_timestamp(timestamp)
     }
 
-    /// Convenience method to check if [`BscHardfork::Pascal`] is firstly active at a given
+    /// Convenience method to check if [`EthereumHardfork::Prague`] is firstly active at a given
     /// timestamp and parent timestamp.
-    fn is_pascal_transition_at_timestamp(&self, timestamp: u64, parent_timestamp: u64) -> bool {
-        self.bsc_fork_activation(BscHardfork::Pascal)
-            .transitions_at_timestamp(timestamp, parent_timestamp)
+    fn is_prague_transition_at_timestamp(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+        self.is_prague_active_at_timestamp(timestamp) && !self.is_prague_active_at_timestamp(parent_timestamp)
     }
 
     /// Convenience method to check if [`BscHardfork::Pascal`] is active at a given timestamp.

--- a/src/hardforks/mod.rs
+++ b/src/hardforks/mod.rs
@@ -186,6 +186,13 @@ pub trait BscHardforks: EthereumHardforks {
         self.bsc_fork_activation(BscHardfork::Bohr).active_at_timestamp(timestamp)
     }
 
+    /// Convenience method to check if [`BscHardfork::Pascal`] is firstly active at a given
+    /// timestamp and parent timestamp.
+    fn is_pascal_transition_at_timestamp(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+        self.bsc_fork_activation(BscHardfork::Pascal)
+            .transitions_at_timestamp(timestamp, parent_timestamp)
+    }
+
     /// Convenience method to check if [`BscHardfork::Pascal`] is active at a given timestamp.
     fn is_pascal_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.bsc_fork_activation(BscHardfork::Pascal).active_at_timestamp(timestamp)

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -418,10 +418,12 @@ where
         }
 
         // enable BEP-440/EIP-2935 for historical block hashes from state
-        if self.spec.is_pascal_transition_at_timestamp(self.evm.block().timestamp.to(), self.evm.block().timestamp.to::<u64>() - 3) {
+        if self.spec.is_prague_transition_at_timestamp(self.evm.block().timestamp.to(), self.evm.block().timestamp.to::<u64>() - 3) {
             self.apply_history_storage_account(self.evm.block().number.to::<u64>())?;
         }
-        self.system_caller.apply_blockhashes_contract_call(self._ctx.parent_hash, &mut self.evm)?;
+        if self.spec.is_prague_active_at_timestamp(self.evm.block().timestamp.to()) {
+            self.system_caller.apply_blockhashes_contract_call(self._ctx.parent_hash, &mut self.evm)?;
+        }
 
         Ok(())
     }

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_consensus::{Transaction, TxReceipt};
 use alloy_eips::{eip7685::Requests, Encodable2718};
 use alloy_evm::{block::ExecutableTx, eth::receipt_builder::ReceiptBuilderCtx};
-use alloy_primitives::{uint, Address, TxKind, U256};
+use alloy_primitives::{uint, Address, TxKind, U256, BlockNumber, Bytes};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -21,6 +21,7 @@ use reth_evm::{
     block::{BlockValidationError, CommitChanges},
     eth::{receipt_builder::ReceiptBuilder, EthBlockExecutionCtx},
     execute::{BlockExecutionError, BlockExecutor},
+    system_calls::SystemCaller,
     Database, Evm, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, OnStateHook, RecoveredTx,
 };
 use reth_primitives::TransactionSigned;
@@ -35,6 +36,9 @@ use revm::{
     state::Bytecode,
     Database as _, DatabaseCommit,
 };
+use tracing::debug;
+use alloy_eips::eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE};
+use alloy_primitives::keccak256;
 
 pub struct BscBlockExecutor<'a, EVM, Spec, R: ReceiptBuilder>
 where
@@ -56,6 +60,8 @@ where
     system_contracts: SystemContract<Spec>,
     /// Context for block execution.
     _ctx: EthBlockExecutionCtx<'a>,
+    /// Utility to call system caller.
+    system_caller: SystemCaller<Spec>,
 }
 
 impl<'a, DB, EVM, Spec, R: ReceiptBuilder> BscBlockExecutor<'a, EVM, Spec, R>
@@ -82,6 +88,7 @@ where
         receipt_builder: R,
         system_contracts: SystemContract<Spec>,
     ) -> Self {
+        let spec_clone = spec.clone();
         Self {
             spec,
             evm,
@@ -91,6 +98,7 @@ where
             receipt_builder,
             system_contracts,
             _ctx,
+            system_caller: SystemCaller::new(spec_clone),
         }
     }
 
@@ -350,6 +358,30 @@ where
         self.transact_system_tx(&tx, validator)?;
         Ok(())
     }
+
+    pub(crate) fn apply_history_storage_account(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<bool, BlockExecutionError> {
+        debug!(
+            "Apply history storage account {:?} at height {:?}",
+            HISTORY_STORAGE_ADDRESS, block_number
+        );
+
+        let account = self.evm.db_mut().load_cache_account(HISTORY_STORAGE_ADDRESS).map_err(|err| {
+            BlockExecutionError::other(err)
+        })?;
+
+        let mut new_info = account.account_info().unwrap_or_default();
+        new_info.code_hash = keccak256(HISTORY_STORAGE_CODE.clone());
+        new_info.code = Some(Bytecode::new_raw(Bytes::from_static(&HISTORY_STORAGE_CODE)));
+        new_info.nonce = 1_u64;
+        new_info.balance = U256::ZERO;
+
+        let transition = account.change(new_info, Default::default());
+        self.evm.db_mut().apply_transition(vec![(HISTORY_STORAGE_ADDRESS, transition)]);
+        Ok(true)
+    }
 }
 
 impl<'a, DB, E, Spec, R> BlockExecutor for BscBlockExecutor<'a, E, Spec, R>
@@ -384,6 +416,12 @@ where
         if !self.spec.is_feynman_active_at_timestamp(self.evm.block().timestamp.to()) {
             self.upgrade_contracts()?;
         }
+
+        // enable BEP-440/EIP-2935 for historical block hashes from state
+        if self.spec.is_pascal_transition_at_timestamp(self.evm.block().timestamp.to(), self.evm.block().timestamp.to::<u64>() - 3) {
+            self.apply_history_storage_account(self.evm.block().number.to::<u64>())?;
+        }
+        self.system_caller.apply_blockhashes_contract_call(self._ctx.parent_hash, &mut self.evm)?;
 
         Ok(())
     }

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -18,7 +18,7 @@ use revm::{
         result::{EVMError, HaltReason, ResultAndState},
         BlockEnv,
     },
-    Context, ExecuteEvm, InspectEvm, Inspector,
+    Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
 };
 
 mod assembler;
@@ -81,11 +81,13 @@ where
 
     fn transact_system_call(
         &mut self,
-        _caller: Address,
-        _contract: Address,
-        _data: Bytes,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        unimplemented!()
+        let result = SystemCallEvm::transact_system_call_with_caller(self, caller, contract, data)?;
+        let state = self.finalize();
+        Ok(ResultAndState::new(result, state))
     }
 
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {


### PR DESCRIPTION
### Description

Enable serving historical block hashes from state (enabled by Prague).

### Rationale

Enable EIP-2935-related state change in apply_pre_execution_changes.

### Example

N/A.

### Changes

Notable changes: 
* apply_pre_execution_changes related.
