### PR TITLE
chore: fix cancun hardfork mapping

### DIFF
--- a/src/hardforks/bsc.rs
+++ b/src/hardforks/bsc.rs
@@ -234,6 +234,7 @@ impl BscHardfork {
             (Self::Feynman.boxed(), ForkCondition::Timestamp(1713419340)), /* 2024-04-18
                                                                             * 05:49:00 AM UTC */
             (Self::FeynmanFix.boxed(), ForkCondition::Timestamp(1713419340)), /* 2024-04-18 05:49:00 AM UTC */
+            (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1718863500)), /* 2024-06-20 06:05:00 AM UTC */
             (Self::Cancun.boxed(), ForkCondition::Timestamp(1718863500)), /* 2024-06-20 06:05:00 AM UTC */
             (Self::Haber.boxed(), ForkCondition::Timestamp(1718863500)), /* 2024-06-20 06:05:00
                                                                           * AM UTC */
@@ -282,6 +283,7 @@ impl BscHardfork {
             (Self::Kepler.boxed(), ForkCondition::Timestamp(1702972800)),
             (Self::Feynman.boxed(), ForkCondition::Timestamp(1710136800)),
             (Self::FeynmanFix.boxed(), ForkCondition::Timestamp(1711342800)),
+            (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1713330442)),
             (Self::Cancun.boxed(), ForkCondition::Timestamp(1713330442)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1716962820)),
             (Self::HaberFix.boxed(), ForkCondition::Timestamp(1719986788)),
@@ -324,6 +326,7 @@ impl BscHardfork {
             (Self::Kepler.boxed(), ForkCondition::Timestamp(1722442622)),
             (Self::Feynman.boxed(), ForkCondition::Timestamp(1722442622)),
             (Self::FeynmanFix.boxed(), ForkCondition::Timestamp(1722442622)),
+            (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(1722442622)),
             (Self::Cancun.boxed(), ForkCondition::Timestamp(1722442622)),
             (Self::Haber.boxed(), ForkCondition::Timestamp(1722442622)),
             (Self::HaberFix.boxed(), ForkCondition::Timestamp(1722442622)),


### PR DESCRIPTION
### Description

Fix Cancun hardfork mapping.

### Rationale

The current mapping relationship between the BSC hard fork, the Eth hard fork, and the EVM Spec is somewhat complicated (as our understanding deepens, we can further refine it).


Reth depends Reth-BSC by https://github.com/loocapro/reth-bsc/blob/49092598f909d9e40f8e9957877c4bf14c5df540/src/chainspec/mod.rs#L122-L126.

EVM depends Reth-BSC by https://github.com/loocapro/reth-bsc/blob/5db30f6aa3cd02459689af8a580e09f2510d4de3/src/hardforks/bsc.rs#L350-L371.

And Reth-BSC load precompiles by https://github.com/loocapro/reth-bsc/blob/5db30f6aa3cd02459689af8a580e09f2510d4de3/src/evm/precompiles/mod.rs#L34-L57.

So we need to reserve the ETH hard fork info.

### Example

N/A.

### Changes

Notable changes: 
* cancun hardfork mapping.
