### PR TITLE
add state hook

### DIFF
--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -479,7 +479,9 @@ where
 
         // Call state hook if it exists, passing the evmstate
         if let Some(hook) = &mut self.hook {
-            hook.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
+            let mut temp_state = state.clone();
+            temp_state.remove(&SYSTEM_ADDRESS);
+            hook.on_state(StateChangeSource::Transaction(self.receipts.len()), &temp_state);
         }
 
         let gas_used = result.gas_used();


### PR DESCRIPTION
### Problem:
The statehook serves as the channel between state root task and execution. During execution, changed state information is passed to the background state root task via hook calls for efficient hash calculation. Currently, the hook-related logic in the BSC executor requires improvements to ensure proper functioning of the state root task.

### Changes:

- Completes the state hook implementation in the BSC executor
- Ensures proper propagation of state changes to the background state root task