### PR TITLE
fix: fix bsc blob params

### DIFF
--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -29,7 +29,12 @@ impl EthChainSpec for BscChainSpec {
     type Header = Header;
 
     fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {
-        self.inner.blob_params_at_timestamp(timestamp)
+        // self.inner.blob_params_at_timestamp(timestamp)
+        if self.inner.is_cancun_active_at_timestamp(timestamp) {
+            Some(self.inner.blob_params.cancun)
+        } else {
+            None
+        }
     }
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {

--- a/src/chainspec/mod.rs
+++ b/src/chainspec/mod.rs
@@ -29,7 +29,8 @@ impl EthChainSpec for BscChainSpec {
     type Header = Header;
 
     fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {
-        // self.inner.blob_params_at_timestamp(timestamp)
+        // BSC doesn't modify blob params in Prague, while ETH does.
+        // This is a key difference between BSC and ETH chain specifications.
         if self.inner.is_cancun_active_at_timestamp(timestamp) {
             Some(self.inner.blob_params.cancun)
         } else {
@@ -163,4 +164,53 @@ impl BscHardforks for Arc<BscChainSpec> {
     fn bsc_fork_activation(&self, fork: BscHardfork) -> ForkCondition {
         self.as_ref().bsc_fork_activation(fork)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chainspec::bsc_chapel::bsc_testnet;
+
+    #[test]
+    fn test_blob_params_at_timestamp() {
+        let chain_spec = BscChainSpec::from(bsc_testnet());
+        
+        // Test timestamp before Cancun (Cancun activates at 1713330442 on testnet)
+        let before_cancun_timestamp = 1713330441;
+        let result = chain_spec.blob_params_at_timestamp(before_cancun_timestamp);
+        assert!(result.is_none(), "Should return None for timestamp before Cancun");
+        
+        // Test timestamp during Cancun (between Cancun and Prague)
+        // Prague activates at 1740452880 on testnet
+        let during_cancun_timestamp = 1713330442; // Cancun activation time
+        let result = chain_spec.blob_params_at_timestamp(during_cancun_timestamp);
+        assert!(result.is_some(), "Should return Some for timestamp during Cancun");
+        if let Some(blob_params) = result {
+            // Check the correct blob param values
+            assert_eq!(blob_params.target_blob_count, 3);
+            assert_eq!(blob_params.max_blob_count, 6);
+        }
+        
+        // Test timestamp after Prague activation
+        let after_prague_timestamp = 1740452880; // Prague activation time
+        let result = chain_spec.blob_params_at_timestamp(after_prague_timestamp);
+        // BSC doesn't modify blob params in Prague, so should still return Cancun params
+        assert!(result.is_some(), "Should return Some for timestamp after Prague (BSC doesn't modify blob params)");
+        if let Some(blob_params) = result {
+            // Check the correct blob param values (should be same as Cancun)
+            assert_eq!(blob_params.target_blob_count, 3);
+            assert_eq!(blob_params.max_blob_count, 6);
+        }
+        
+        // Test timestamp well after Prague
+        let well_after_prague_timestamp = 1740452881;
+        let result = chain_spec.blob_params_at_timestamp(well_after_prague_timestamp);
+        assert!(result.is_some(), "Should return Some for timestamp well after Prague");
+        if let Some(blob_params) = result {
+            // Check the correct blob param values (should be same as Cancun)
+            assert_eq!(blob_params.target_blob_count, 3);
+            assert_eq!(blob_params.max_blob_count, 6);
+        }
+    }
+    
 }


### PR DESCRIPTION
### Description

Fix BSC blob params.

### Rationale

BSC doesn't modify blob params in Prague, while ETH does. This is a key difference between BSC and ETH chain specifications.

Incorrect blob params can cause validate_header_against_parent to fail, causing the header stage sync stuck(testnet stuck at https://testnet.bscscan.com/block/49404920).

### Example

N/A.

### Changes

Notable changes: 
* blob_params_at_timestamp related.

### Potential Impacts

N/A.
