### PR TITLE
Remove PrecompileProvider  impl for BscPrecompiles

### DIFF
--- a/src/evm/precompiles/mod.rs
+++ b/src/evm/precompiles/mod.rs
@@ -2,14 +2,11 @@
 
 use crate::hardforks::bsc::BscHardfork;
 use cfg_if::cfg_if;
-use once_cell::{race::OnceBox, sync::Lazy};
+use once_cell::race::OnceBox;
 use revm::{
     context::Cfg,
-    context_interface::ContextTr,
-    handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::{InputsImpl, InterpreterResult},
+    handler::EthPrecompiles,
     precompile::{bls12_381, kzg_point_evaluation, modexp, secp256r1, Precompiles},
-    primitives::{hardfork::SpecId, Address},
 };
 use std::boxed::Box;
 
@@ -193,41 +190,6 @@ pub fn pascal() -> &'static Precompiles {
         };
         Box::new(precompiles)
     })
-}
-
-impl<CTX> PrecompileProvider<CTX> for BscPrecompiles
-where
-    CTX: ContextTr<Cfg: Cfg<Spec = BscHardfork>>,
-{
-    type Output = InterpreterResult;
-
-    #[inline]
-    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
-        *self = Self::new(spec);
-        true
-    }
-
-    #[inline]
-    fn run(
-        &mut self,
-        context: &mut CTX,
-        address: &Address,
-        inputs: &InputsImpl,
-        is_static: bool,
-        gas_limit: u64,
-    ) -> Result<Option<Self::Output>, String> {
-        self.inner.run(context, address, inputs, is_static, gas_limit)
-    }
-
-    #[inline]
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        self.inner.warm_addresses()
-    }
-
-    #[inline]
-    fn contains(&self, address: &Address) -> bool {
-        self.inner.contains(address)
-    }
 }
 
 impl Default for BscPrecompiles {


### PR DESCRIPTION
### Description
Since the `BscEvm` already utilizes `PrecompilesMap`, it is no longer necessary to implement `PrecompileProvider` for `BscPrecompiles` as required in recent versions of Reth.

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
