### PR TITLE
fix: fix apply hash to modify system account state

### DIFF
--- a/src/evm/api/exec.rs
+++ b/src/evm/api/exec.rs
@@ -3,7 +3,7 @@ use crate::evm::{
     handler::BscHandler,
     transaction::BscTxEnv,
 };
-use alloy_primitives::{Address, Bytes};
+
 use reth_evm::Database;
 use revm::{
     context::{BlockEnv, ContextSetters},
@@ -11,7 +11,7 @@ use revm::{
         result::{EVMError, ExecutionResult, ResultAndState},
         ContextTr,
     },
-    handler::{Handler, SystemCallEvm},
+    handler::Handler,
     inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler},
     state::EvmState,
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
@@ -79,52 +79,4 @@ where
     DB: Database + DatabaseCommit,
     INSP: Inspector<BscContext<DB>>,
 {
-}
-
-impl<DB, INSP> SystemCallEvm for BscEvm<DB, INSP>
-where
-    DB: Database,
-{
-    fn transact_system_call(
-        &mut self,
-        _contract: Address,
-        _data: Bytes,
-    ) -> Result<ExecutionResult, Self::Error> {
-        unimplemented!()
-    }
-
-    fn transact_system_call_with_caller(
-        &mut self,
-        caller: Address,
-        contract: Address,
-        data: Bytes,
-    ) -> Result<ExecutionResult, Self::Error> {
-        let tx = BscTxEnv {
-            base: revm::context::TxEnv {
-                caller,
-                kind: alloy_primitives::TxKind::Call(contract),
-                nonce: 0,
-                gas_limit: self.inner.ctx.block.gas_limit,
-                value: alloy_primitives::U256::ZERO,
-                data,
-                gas_price: 0,
-                chain_id: Some(self.inner.ctx.cfg.chain_id),
-                gas_priority_fee: None,
-                access_list: Default::default(),
-                blob_hashes: Vec::new(),
-                max_fee_per_blob_gas: 0,
-                tx_type: 0,
-                authorization_list: Default::default(),
-            },
-           is_system_transaction: true,
-        };
-        
-        // disable nonce check for system calls
-        let original_disable_nonce_check = self.inner.ctx.cfg.disable_nonce_check;
-        self.inner.ctx.cfg.disable_nonce_check = true;
-        let result = self.transact_one(tx);
-        self.inner.ctx.cfg.disable_nonce_check = original_disable_nonce_check;
-        
-        result
-    }
 }

--- a/src/evm/transaction.rs
+++ b/src/evm/transaction.rs
@@ -5,6 +5,7 @@ use reth_rpc_eth_api::transaction::TryIntoTxEnv;
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::transaction::Transaction,
+    handler::SystemCallTx,
     primitives::{Address, Bytes, TxKind, B256, U256},
 };
 
@@ -135,6 +136,27 @@ impl TransactionEnv for BscTxEnv {
 
     fn set_access_list(&mut self, access_list: AccessList) {
         self.base.set_access_list(access_list);
+    }
+}
+
+impl SystemCallTx for BscTxEnv {
+    fn new_system_tx_with_caller(
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Self {
+        let base = TxEnv::builder()
+            .caller(caller)
+            .data(data)
+            .kind(TxKind::Call(system_contract_address))
+            .gas_limit(30_000_000) // Use BSC's gas limit for system calls
+            .build()
+            .unwrap();
+
+        Self {
+            base,
+            is_system_transaction: true,
+        }
     }
 }
 

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_consensus::{Transaction, TxReceipt};
 use alloy_eips::{eip7685::Requests, Encodable2718};
 use alloy_evm::{block::{ExecutableTx, StateChangeSource}, eth::receipt_builder::ReceiptBuilderCtx};
-use alloy_primitives::{uint, Address, TxKind, U256, BlockNumber, Bytes, B256};
+use alloy_primitives::{uint, Address, TxKind, U256, BlockNumber, Bytes};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
@@ -33,7 +33,7 @@ use revm::{
         result::{ExecutionResult, ResultAndState},
         TxEnv,
     },
-    state::{Bytecode, AccountInfo},
+    state::Bytecode,
     Database as _, DatabaseCommit,
 };
 use tracing::debug;
@@ -430,25 +430,6 @@ where
         }
         if self.spec.is_prague_active_at_timestamp(self.evm.block().timestamp.to()) {
             self.system_caller.apply_blockhashes_contract_call(self._ctx.parent_hash, &mut self.evm)?;
-
-            // reset system address - clear balance, nonce, and code
-            let system_account = self
-                .evm
-                .db_mut()
-                .load_cache_account(SYSTEM_ADDRESS)
-                .map_err(BlockExecutionError::other)?;
-            if system_account.account.is_some() {
-                // Create a completely empty account info
-                let empty_info = AccountInfo {
-                    balance: U256::ZERO,
-                    nonce: 0,
-                    code_hash: B256::ZERO,
-                    code: None,
-                };
-                // Change the account to empty state
-                let transition = system_account.change(empty_info, Default::default());
-                self.evm.db_mut().apply_transition(vec![(SYSTEM_ADDRESS, transition)]);
-            }
         }
 
         Ok(())

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -85,7 +85,7 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let result = SystemCallEvm::transact_system_call_with_caller(self, caller, contract, data)?;
+        let result = self.inner.transact_system_call_with_caller(caller, contract, data)?;
         let state = self.finalize();
         Ok(ResultAndState::new(result, state))
     }


### PR DESCRIPTION
### Description

Avoid applying hash to modify system account state.

### Rationale

https://github.com/loocapro/reth-bsc/blob/main/src/evm/api/exec.rs#L96

The tx will increase the system-account nonce. 

Whether the system-account exists may affect gas calculation, https://github.com/bluealloy/revm/blob/main/crates/interpreter/src/gas/calc.rs#L282

Which is unexpected.


### Example

https://testnet.bscscan.com/tx/0xe41bddc87440a22937cf6aee2294fa3415bfb464e534a935457cda22228f6bd2#internal, whether this transaction is executed correctly depends on whether the system account exists.

### Changes

Notable changes: 
* Directly use the systemcall interface to replace the tx execution interface. tx execution will modify the system account state.

### Potential Impacts
N/A.
